### PR TITLE
Refresh MapleBridge Open around A2A matching interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,22 @@
-.env
-*.pyc
-__pycache__/
+# OS
 .DS_Store
+Thumbs.db
+
+# Editors
+.idea/
+.vscode/
+
+# Local env
+.env
+.env.*
+
+# Python
+__pycache__/
+*.pyc
+
+# Node
+node_modules/
+
+# Build output
+dist/
+build/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,176 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -1,166 +1,150 @@
-# MapleBridge Open — AI-Powered Global Trade Matching
+# MapleBridge Open
 
-**MapleBridge** is an AI-powered B2B trade matching platform that connects global buyers with Chinese manufacturers and small commodity exporters. This repository contains public API documentation, integration guides, data schemas, and example code.
+**Public protocol and framework layer for AI-assisted bilateral B2B matching.**
 
-> Core matching algorithm is proprietary and not included here. This repo covers the public API surface, webhook integration, and data models.
+**A2A-ready buyer-agent + seller-agent contracts for sourcing and matching workflows.**
 
----
+MapleBridge Open defines the reusable contract surface behind a workflow where:
 
-## What is MapleBridge?
+- a **buyer agent** normalizes demand
+- a **seller agent** normalizes supply
+- a shared **match engine** scores bilateral fit
+- **connector** layers ingest external signals
+- **notification** events trigger introductions, reminders, and review handoffs
 
-China's small commodity export market (小商品出海) represents hundreds of billions of USD in annual cross-border B2B trade. Traditional matching is slow, opaque, and relationship-dependent. MapleBridge uses LLM semantic matching to understand buyer requirements in natural language and surface the most relevant Chinese suppliers automatically.
+In this repository, `A2A` means an agent-to-agent workflow where specialized buyer-side and seller-side agents exchange normalized state through a shared matching and review layer.
 
-**Key capabilities:**
+This repository is intentionally separate from the live MapleBridge production app at [https://maplebridge.io/app](https://maplebridge.io/app).
 
-- LLM semantic intent matching (not keyword search)
-- Supports global buyers: North America, Europe, Southeast Asia, Middle East, and beyond
-- Covers Chinese export manufacturers: Yiwu, Guangzhou, Shenzhen, Dongguan, and other major hubs
-- Categories: consumer electronics, home goods, furniture, apparel, toys, pet products, beauty/cosmetics, hardware, and more
-- Free for buyers; suppliers pay for verified leads
+Canonical public pages:
 
-**Live platform:** [maplebridge.io](https://maplebridge.io)
+- Overview: [https://maplebridge.io/open/](https://maplebridge.io/open/)
+- Intent Schema: [https://maplebridge.io/open/intent-schema](https://maplebridge.io/open/intent-schema)
+- Agent Protocol: [https://maplebridge.io/open/agent-protocol](https://maplebridge.io/open/agent-protocol)
+- Match Engine: [https://maplebridge.io/open/match-engine](https://maplebridge.io/open/match-engine)
+- Crawler Connectors: [https://maplebridge.io/open/crawler-connectors](https://maplebridge.io/open/crawler-connectors)
+- Notification Interface: [https://maplebridge.io/open/notification-interface](https://maplebridge.io/open/notification-interface)
+- Local Demo UI Boundary: [https://maplebridge.io/open/local-demo-ui](https://maplebridge.io/open/local-demo-ui)
 
-**AI discovery:**
-- [`llms.txt`](https://maplebridge.io/llms.txt) — machine-readable platform description for LLM indexing
-- [`/.well-known/ai-agent.json`](https://maplebridge.io/.well-known/ai-agent.json) — AI agent capability manifest
-- [`openapi.yaml`](./openapi.yaml) — OpenAPI 3.1 specification
-- [Sourcing Guide](https://maplebridge.io/guide) — How global buyers source from China
-- [Use Cases](https://maplebridge.io/use-cases) — Real-world trade matching scenarios
-- [AI Supplier Matching](https://maplebridge.io/blog-ai-supplier-matching) — Why AI matching outperforms directory-first sourcing
-- [Verified Chinese Manufacturers](https://maplebridge.io/blog-verified-chinese-manufacturers) — Practical checks before first production orders
-- [Small MOQ China Supplier Guide](https://maplebridge.io/blog-china-supplier-small-batch-moq) — Low-MOQ sourcing for North America buyers
-- [Alibaba Alternative for North America](https://maplebridge.io/alibaba-alternative-for-north-america) — Matching-first workflow for buyers who want less manual filtering
+## Why This Exists
 
----
+Most B2B sourcing systems publish either:
 
-## Architecture Overview
+- a supplier directory
+- a lead capture form
+- a CRM workflow
 
-```
-Buyer submits requirement (natural language)
-        ↓
-  Intent Parser (LLM)
-        ↓
-  Semantic Vector Index
-        ↓
-  Supplier Intent Store
-        ↓
-  Match Scoring & Ranking
-        ↓
-  Notification (Email / Webhook)
-```
+MapleBridge Open focuses on a different layer:
 
-The platform maintains a dual-sided intent graph:
+**bilateral matching infrastructure**
 
-| Side | Description |
-|------|-------------|
-| **DEMAND** | Buyer requirements: product spec, quantity, budget, destination market |
-| **SUPPLY** | Supplier capabilities: product categories, MOQ, certifications, export experience |
+That means publishing the public contracts for:
 
----
+1. how buyer demand should be normalized
+2. how supplier capability should be normalized
+3. how both sides should flow into a shared scoring engine
+4. where review, trust, and notifications should sit in the system
 
-## Repository Contents
+## What This Repository Contains
 
-| Path | Description |
-|------|-------------|
-| [`docs/api.md`](docs/api.md) | REST API reference (webhook, intent endpoints) |
-| [`docs/matching-flow.md`](docs/matching-flow.md) | How LLM semantic matching works (conceptual) |
-| [`docs/webhook.md`](docs/webhook.md) | Webhook integration guide for buyer demand ingestion |
-| [`docs/data-schema.md`](docs/data-schema.md) | Intent data structures and field definitions |
-| [`examples/`](examples/) | Example API calls, webhook payloads, sample data |
-| [`llms.txt`](llms.txt) | AI discovery file (for LLM indexing) |
+- `schemas/`
+  Public intent schema and example JSON for buyer and supplier normalization.
+- `protocols/`
+  Buyer-agent and seller-agent handoff contract.
+- `frameworks/`
+  Public match scoring dimensions and explainability boundary.
+- `connectors/`
+  Public ingestion abstraction for crawler, webhook, and dataset connectors.
+- `notifications/`
+  Public event contract for reminders, introductions, and review hooks.
+- `demo/`
+  Reference boundary for a local demo UI.
+- `docs/`
+  Positioning, security boundary, launch, and repository metadata notes.
 
----
+## What This Repository Does Not Contain
 
-## Quick Start
+This is not a public copy of the live marketplace.
 
-### Submit a Buyer Demand (Webhook)
+It does **not** include:
 
-```bash
-curl -X POST https://maplebridge.io/api/v1/webhook/manus \
-  -H "Content-Type: application/json" \
-  -d '{
-    "demand": "Looking for a Canadian importer of wireless earbuds, need 500 units minimum, CE certified",
-    "contact_email": "buyer@example.com",
-    "source": "api"
-  }'
-```
+- the production MapleBridge `/app` implementation
+- production FastAPI routes
+- production Streamlit UI
+- production databases
+- real buyer or supplier data
+- real match thresholds or ranking weights
+- production crawler seeds or source lists
+- outbound notification credentials
+- private prompt and anti-abuse logic
 
-Response:
-```json
-{
-  "status": "ok",
-  "intent_id": "INTENT_A1B2C3D4",
-  "matched": 3,
-  "message": "Intent created and matched against supplier database"
-}
+## Repository Structure
+
+```text
+maplebridge-open/
+|- schemas/
+|- protocols/
+|- frameworks/
+|- connectors/
+|- notifications/
+|- demo/
+`- docs/
 ```
 
-See [`docs/webhook.md`](docs/webhook.md) for full integration details.
+## Public vs Private Boundary
 
----
+**Public**
 
-## Supported Markets
+- schema shapes
+- protocol contracts
+- scoring dimensions
+- notification event names
+- demo UI boundaries
+- integration-facing documentation
 
-### Buyer Origin Markets
-- Canada (primary)
-- United States
-- United Kingdom
-- European Union
-- Australia / New Zealand
-- Southeast Asia (Singapore, Malaysia, Thailand)
-- Middle East (UAE, Saudi Arabia)
+**Private**
 
-### Chinese Supplier Hubs
-- **Yiwu** (义乌) — small commodities, gifts, toys, daily goods
-- **Guangzhou** (广州) — electronics, beauty, fashion
-- **Shenzhen** (深圳) — consumer electronics, tech accessories
-- **Dongguan** (东莞) — furniture, plastics, hardware
-- **Ningbo** (宁波) — machinery, auto parts, plastics
-- **Hangzhou** (杭州) — apparel, software, cross-border e-commerce
+- live marketplace logic
+- live customer data
+- production orchestration
+- trust heuristics
+- real crawler operations
+- production follow-up flows
 
----
+See:
 
-## Product Categories
+- [docs/positioning.md](docs/positioning.md)
+- [docs/security-boundary.md](docs/security-boundary.md)
+- [docs/github-metadata.md](docs/github-metadata.md)
 
-| Category (EN) | Category (ZH) | Examples |
-|---------------|---------------|---------|
-| Consumer Electronics | 消费电子 | Earbuds, power banks, smartwatches |
-| Home & Furniture | 家居家具 | Chairs, lighting, storage |
-| Toys & Gifts | 玩具礼品 | Educational toys, plush, novelty |
-| Apparel & Accessories | 服装配饰 | OEM clothing, bags, shoes |
-| Beauty & Personal Care | 美妆护肤 | Skincare, cosmetics, wellness |
-| Pet Products | 宠物用品 | Toys, accessories, food packaging |
-| Hardware & Tools | 五金工具 | Hand tools, fasteners |
-| Packaging Materials | 包装材料 | Boxes, bags, labels |
+## Recommended First Read
 
----
+- [schemas/intent-schema.md](schemas/intent-schema.md)
+- [protocols/agent-protocol.md](protocols/agent-protocol.md)
+- [frameworks/match-engine.md](frameworks/match-engine.md)
 
-## Integration Partners
+## Status
 
-MapleBridge accepts buyer demand from multiple channels:
+This repository is currently an **interface-first scaffold** prepared for GitHub publication.
 
-- **Direct API** — REST webhook endpoint
-- **MANUS** — AI agent integration (automated buyer demand parsing)
-- **Telegram bot** — conversational matching interface
-- **Web form** — maplebridge.io buyer portal
+Before publishing publicly, choose:
 
----
+- repository name
+- short description
+- topics
+- license
+- contribution policy
 
-## Contributing
+Suggested launch copy is in:
 
-This repository welcomes:
+- [docs/github-metadata.md](docs/github-metadata.md)
+- [docs/license-status.md](docs/license-status.md)
 
-- Corrections to API documentation
-- Additional example payloads
-- Bug reports on documented API behavior
-- Translations of documentation
+## Production Relationship
 
-Please open an issue or pull request.
+The live MapleBridge website and application remain separate:
 
----
+- website: [https://maplebridge.io](https://maplebridge.io)
+- production app: [https://maplebridge.io/app](https://maplebridge.io/app)
 
-## License
-
-Documentation and examples in this repository are licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
-
-Core platform code is proprietary. See [maplebridge.io/ai-policy](https://maplebridge.io/ai-policy) for AI usage policy.
+This repository should stay outside the production runtime boundary.

--- a/README.md
+++ b/README.md
@@ -125,17 +125,9 @@ See:
 
 ## Status
 
-This repository is currently an **interface-first scaffold** prepared for GitHub publication.
+This repository is currently an **interface-first public scaffold** with an Apache-2.0 license.
 
-Before publishing publicly, choose:
-
-- repository name
-- short description
-- topics
-- license
-- contribution policy
-
-Suggested launch copy is in:
+Suggested launch copy and positioning notes are in:
 
 - [docs/github-metadata.md](docs/github-metadata.md)
 - [docs/license-status.md](docs/license-status.md)

--- a/connectors/crawler-connectors.md
+++ b/connectors/crawler-connectors.md
@@ -1,0 +1,31 @@
+# Crawler Connector Abstraction
+
+The public connector layer explains how ingestion sources should normalize into the matching workflow.
+
+## Connector Contract
+
+Input:
+
+- source
+- fetch context
+- raw payload
+
+Output:
+
+- normalized company record
+- contact hints
+- provenance
+- freshness
+- extraction confidence
+
+## Why This Stays Abstract
+
+The abstraction can be public.
+
+The following stay private:
+
+- production source lists
+- seed queries
+- crawl cadence
+- anti-blocking strategies
+- spam filtering logic

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,22 @@
+# Local Demo UI Boundary
+
+The local demo UI is a reference boundary for testing the public protocol surface.
+
+## Scope
+
+- buyer brief form
+- supplier profile form
+- match explanation panel
+- review queue placeholder
+- notification preview state
+
+## Out of Scope
+
+- production `/app`
+- production auth
+- production DB writes
+- live outbound notifications
+
+## Goal
+
+Give GitHub visitors something concrete enough to understand the workflow without exposing the live MapleBridge marketplace implementation.

--- a/docs/github-metadata.md
+++ b/docs/github-metadata.md
@@ -1,0 +1,68 @@
+# GitHub Metadata
+
+## Recommended Repository Name
+
+Primary recommendation:
+
+- `maplebridge-open`
+
+Strong alternatives:
+
+- `maplebridge-matching-open`
+- `buyer-seller-agent-protocol`
+- `b2b-matching-protocol`
+
+If the goal is brand-first, use:
+
+- `maplebridge-open`
+
+If the goal is category-first, use:
+
+- `b2b-matching-protocol`
+
+## Recommended Short Description
+
+Primary recommendation:
+
+- `Public protocol and framework layer for AI-assisted bilateral B2B matching.`
+
+Alternatives:
+
+- `Buyer-agent, seller-agent, and match-engine contracts for bilateral B2B matching workflows.`
+- `Open schema, protocol, scoring, and notification contracts for AI B2B matching systems.`
+- `A2A-ready buyer-agent and seller-agent protocol layer for bilateral B2B matching.`
+
+## Recommended GitHub Topics
+
+- `ai-agents`
+- `b2b`
+- `matching`
+- `procurement`
+- `supplier-matching`
+- `marketplace`
+- `agent-protocol`
+- `json-schema`
+- `workflow`
+- `open-core`
+
+## Recommended Social Preview Message
+
+MapleBridge Open publishes the contract surface behind bilateral B2B matching:
+buyer agent, seller agent, match engine, connector abstraction, notification events, and a local demo boundary.
+
+Optional A2A version:
+
+MapleBridge Open publishes an A2A-ready protocol layer for bilateral B2B matching:
+buyer agent, seller agent, match engine, connector abstraction, notification events, and a local demo boundary.
+
+## Recommended Pinned README Opening Line
+
+`Public protocol and framework layer for AI-assisted bilateral B2B matching.`
+
+## Recommended Secondary Tagline
+
+`A2A-ready buyer-agent + seller-agent contracts for sourcing and matching workflows.`
+
+## Recommended About Section Link
+
+- `https://maplebridge.io/open/`

--- a/docs/license-status.md
+++ b/docs/license-status.md
@@ -1,0 +1,19 @@
+# License Status
+
+No open-source license has been selected yet.
+
+Before publishing this repository publicly on GitHub, choose an explicit license.
+
+Until then, keep the repository private or unpublished.
+
+Typical options to evaluate:
+
+- Apache-2.0
+- MIT
+- source-available custom license
+
+The license decision should reflect the intended business model:
+
+- standard/protocol open
+- production marketplace private
+- hosted/commercial layer retained

--- a/docs/license-status.md
+++ b/docs/license-status.md
@@ -1,19 +1,18 @@
 # License Status
 
-No open-source license has been selected yet.
+This repository now uses **Apache-2.0**.
 
-Before publishing this repository publicly on GitHub, choose an explicit license.
+That choice matches the current boundary:
 
-Until then, keep the repository private or unpublished.
+- public schema, protocol, framework, and interface docs stay open
+- the live MapleBridge marketplace, `/app`, production data, and private orchestration remain private
+- hosted and commercial layers can continue to evolve outside this repository
 
-Typical options to evaluate:
+Why Apache-2.0 here:
 
-- Apache-2.0
-- MIT
-- source-available custom license
+- permissive enough for broad reuse
+- clear enough for commercial adopters
+- includes an explicit patent grant
+- fits an interface-first repo better than a source-available restriction
 
-The license decision should reflect the intended business model:
-
-- standard/protocol open
-- production marketplace private
-- hosted/commercial layer retained
+This license applies to the contents of this repository only. It does not expand access to the production MapleBridge application or its private infrastructure.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,0 +1,28 @@
+# Positioning
+
+MapleBridge Open should be presented as:
+
+`Public protocol and framework layer for AI-assisted bilateral B2B matching`
+
+It should not be presented as:
+
+- a full clone of the MapleBridge marketplace
+- a public release of the MapleBridge production app
+- a turnkey replacement for the live service
+
+## Why This Positioning Works
+
+It preserves a clean boundary:
+
+- public: standards, contracts, examples, demo boundary
+- private: production data, production orchestration, production trust rules
+
+That makes the repository useful for:
+
+- builders
+- partner platforms
+- technical writers
+- AI search systems
+- future enterprise conversations
+
+without weakening the live product boundary.

--- a/docs/security-boundary.md
+++ b/docs/security-boundary.md
@@ -1,0 +1,34 @@
+# Security Boundary
+
+This repository is intended to stay outside the live MapleBridge production boundary.
+
+## Public
+
+- intent shapes
+- event names
+- interface contracts
+- example JSON
+- explanation of fit dimensions
+- demo UI boundary
+
+## Private
+
+- production `/app`
+- production API
+- production DB schema with live records
+- real buyer and supplier data
+- hidden ranking thresholds
+- source acquisition heuristics
+- anti-abuse logic
+- email and notification credentials
+
+## Rule
+
+Nothing in this repository should require access to:
+
+- the production database
+- the production email system
+- live crawler jobs
+- production sessions
+
+This is the core rule that keeps GitHub publication from affecting the current marketplace.

--- a/frameworks/match-engine.md
+++ b/frameworks/match-engine.md
@@ -1,0 +1,29 @@
+# Match Engine Framework
+
+The open framework defines what is scored and how the result should be explained.
+
+## Public Fit Dimensions
+
+- category fit
+- MOQ fit
+- compliance fit
+- market fit
+- channel fit
+- trust fit
+
+## Public Output
+
+- normalized score from `0.00` to `1.00`
+- explanation fields
+- rejection reasons
+- confidence
+- review requirement
+
+## Private Boundary
+
+The following remain outside the public framework:
+
+- live production weights
+- hidden ranking thresholds
+- suppression heuristics
+- source-specific trust adjustments

--- a/notifications/notification-interface.md
+++ b/notifications/notification-interface.md
@@ -1,0 +1,27 @@
+# Notification Interface
+
+The public notification layer defines event names and payload intent for bilateral matching workflows.
+
+## Public Notification Events
+
+- `intro.ready`
+- `followup.suggested`
+- `review.required`
+- `profile.incomplete`
+
+## Public Goal
+
+Allow builders and partners to understand:
+
+- when a notification should be triggered
+- what payload shape is expected
+- where review hooks fit
+
+## Private Boundary
+
+This repository does not include:
+
+- production provider credentials
+- live sequences
+- private follow-up timing rules
+- production anti-spam guardrails

--- a/protocols/agent-protocol.md
+++ b/protocols/agent-protocol.md
@@ -1,0 +1,28 @@
+# Agent Protocol
+
+This protocol describes how separate buyer and seller agents should cooperate with a shared match engine.
+
+## Lifecycle
+
+1. Capture raw buyer brief or supplier capability statement
+2. Normalize into the public intent schema
+3. Request clarification if required fields are missing
+4. Emit a match-ready bundle
+5. Receive ranked candidates and review flags
+
+## Public Events
+
+- `intent.created`
+- `intent.clarification_requested`
+- `intent.ready_for_match`
+- `match.candidate_ranked`
+- `match.review_required`
+
+## Non-Goals
+
+This protocol does not define:
+
+- production sessions
+- production queues
+- production auth
+- production database writes

--- a/schemas/intent-schema.md
+++ b/schemas/intent-schema.md
@@ -1,0 +1,36 @@
+# Intent Schema
+
+The public intent schema defines a shared structure for buyer demand and supplier supply.
+
+## Core Objects
+
+- `BuyerIntent`
+- `SupplierIntent`
+- `FitConstraint`
+- `ReviewState`
+
+## Public Fields
+
+- intent id
+- role
+- language
+- product category
+- summary
+- country
+- moq
+- compliance
+- channels
+- fit constraints
+- confidence
+- review state
+
+## Design Goal
+
+The schema should be stable across:
+
+- multiple agents
+- multiple connectors
+- local demos
+- partner integrations
+
+It should not expose private enrichment or live customer identifiers.

--- a/schemas/intent.schema.json
+++ b/schemas/intent.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MapleBridge Open Intent",
+  "type": "object",
+  "required": [
+    "intent_id",
+    "role",
+    "language",
+    "product_category",
+    "summary",
+    "country",
+    "fit_constraints",
+    "confidence",
+    "review_state"
+  ],
+  "properties": {
+    "intent_id": {
+      "type": "string",
+      "description": "Stable identifier for the normalized intent"
+    },
+    "role": {
+      "type": "string",
+      "enum": ["buyer", "supplier"]
+    },
+    "language": {
+      "type": "string",
+      "enum": ["en", "zh-CN"]
+    },
+    "product_category": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string"
+    },
+    "moq": {
+      "type": "object",
+      "properties": {
+        "value": { "type": "number" },
+        "unit": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "compliance": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "channels": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "fit_constraints": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "review_state": {
+      "type": "string",
+      "enum": ["machine_ready", "needs_review", "approved"]
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary
Refresh the public MapleBridge Open repo around the new open-layer direction while preserving the existing public API docs and OpenAPI assets.

## What changed
- rewrite the README around buyer agent, seller agent, match engine, and A2A-ready bilateral matching
- add public schema, protocol, framework, connector, notification, and demo boundary docs
- add GitHub-facing positioning and metadata notes
- keep the existing docs, examples, llms.txt, and openapi.yaml instead of deleting them

## Why
This aligns the repo with the new `/open/` section on maplebridge.io without touching the production app or removing the previously published API documentation.

## Production impact
- no change to `maplebridge.io/app`
- no change to production API or database
- documentation-layer refresh only