### PR TITLE
Add open repo operations scaffold

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Report a problem in the public repository docs, examples, or contract layer.
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Summary
+
+Describe the problem clearly.
+
+## Location
+
+Which file or public page is affected?
+
+## Expected behavior
+
+What should have happened?
+
+## Actual behavior
+
+What happened instead?
+
+## Notes
+
+Add any extra context here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: MapleBridge Open overview
+    url: https://maplebridge.io/open/
+    about: Read the public overview before opening a new issue.
+  - name: Security boundary
+    url: https://github.com/jinjihuang88-ui/maplebridge-open/blob/main/docs/security-boundary.md
+    about: Check the public versus private boundary before proposing production-facing changes.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a public contract, example, or documentation improvement.
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Request
+
+Describe the improvement you want.
+
+## Why it matters
+
+Explain the builder or integration value.
+
+## Proposed scope
+
+Keep the proposal inside the public contract boundary if possible.
+
+## Notes
+
+Add examples, references, or constraints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable public-facing changes to this repository should be recorded here.
+
+This changelog covers the open contract layer only. It does not describe changes to the private MapleBridge production app.
+
+## 2026-04-11
+
+### Added
+
+- initial public repository positioning for MapleBridge Open
+- intent schema documentation and JSON schema
+- buyer-agent and seller-agent protocol documentation
+- public match-engine framework notes
+- crawler connector abstraction notes
+- notification interface notes
+- local demo UI boundary notes
+- A2A positioning note
+- Apache-2.0 license
+- roadmap and contribution guidance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+
+MapleBridge Open accepts contributions to the public contract layer.
+
+## Good Contribution Targets
+
+- schema clarity
+- protocol naming and field consistency
+- documentation fixes
+- example payload improvements
+- explainability and integration notes
+
+## Out of Scope
+
+Do not propose changes that require:
+
+- access to the private MapleBridge production app
+- production data
+- production crawler operations
+- private ranking thresholds
+- live notification credentials
+
+## Contribution Rules
+
+1. Keep changes inside the open contract boundary.
+2. Prefer documentation and example-first pull requests.
+3. Explain whether a proposed change affects schema compatibility.
+4. Do not include secrets, customer data, or production-only logic.
+
+## Before Opening a Pull Request
+
+- read [README.md](README.md)
+- read [docs/security-boundary.md](docs/security-boundary.md)
+- check [ROADMAP.md](ROADMAP.md) for current priorities
+- add a changelog note if the public interface changed
+
+## Issue Guidance
+
+Use issues for:
+
+- schema questions
+- protocol gaps
+- match-engine explainability suggestions
+- connector interface requests
+
+Use discussions, when enabled, for:
+
+- design questions
+- ecosystem ideas
+- integration concepts

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ See:
 - [docs/why-a2a.md](docs/why-a2a.md)
 - [docs/security-boundary.md](docs/security-boundary.md)
 - [docs/github-metadata.md](docs/github-metadata.md)
+- [ROADMAP.md](ROADMAP.md)
+- [CHANGELOG.md](CHANGELOG.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Recommended First Read
 
@@ -133,6 +136,12 @@ Suggested launch copy and positioning notes are in:
 
 - [docs/github-metadata.md](docs/github-metadata.md)
 - [docs/license-status.md](docs/license-status.md)
+
+## Operating Notes
+
+- roadmap: [ROADMAP.md](ROADMAP.md)
+- changelog: [CHANGELOG.md](CHANGELOG.md)
+- contributions: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Production Relationship
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,50 @@
+# Roadmap
+
+This repository is intentionally interface-first. The roadmap is organized around what should become public and reusable without crossing the MapleBridge production boundary.
+
+## Phase 1: Public Contract Layer
+
+Status: in progress
+
+- publish intent schema for bilateral buyer and supplier normalization
+- publish buyer-agent and seller-agent protocol contracts
+- publish public match-engine dimensions and explainability notes
+- publish notification event interface
+- publish a clear A2A positioning note
+
+## Phase 2: Builder-Facing Examples
+
+Status: next
+
+- add example buyer intent payloads for multiple sourcing scenarios
+- add example seller capability payloads for OEM, ODM, and low-MOQ cases
+- add end-to-end sample match explanations
+- add connector examples for webhook, CSV, and crawler ingestion
+- add a local reference demo flow that never touches production systems
+
+## Phase 3: Open Integration Surface
+
+Status: planned
+
+- publish a lightweight integration guide for partner platforms
+- document trust and review handoff boundaries
+- add versioned contract notes
+- add migration guidance for future schema revisions
+
+## Phase 4: Ecosystem Readiness
+
+Status: planned
+
+- publish first tagged release
+- maintain changelog entries for public contract changes
+- enable repository discussions for builder questions
+- collect issue-driven feedback on schema and protocol design
+
+## Explicit Non-Goals
+
+The roadmap does not include:
+
+- opening the production MapleBridge app
+- exposing live crawler sources or orchestration rules
+- publishing production ranking thresholds
+- exposing live customer or partner data


### PR DESCRIPTION
## Summary
Add the first repository operations scaffold for MapleBridge Open.

## What changed
- add `ROADMAP.md`
- add `CHANGELOG.md`
- add `CONTRIBUTING.md`
- add issue templates for bug reports and feature requests
- link these operating docs from `README.md`

## Why
The public repo now has the minimum operating layer needed for ongoing issues, release notes, and roadmap visibility.

## Production impact
- no change to `maplebridge.io/app`
- repository-only documentation and issue template update