### PR TITLE
Add release and partner integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ See:
 - [docs/positioning.md](docs/positioning.md)
 - [docs/why-a2a.md](docs/why-a2a.md)
 - [docs/security-boundary.md](docs/security-boundary.md)
+- [docs/release-process.md](docs/release-process.md)
+- [docs/partner-integration-guide.md](docs/partner-integration-guide.md)
 - [docs/github-metadata.md](docs/github-metadata.md)
 - [ROADMAP.md](ROADMAP.md)
 - [CHANGELOG.md](CHANGELOG.md)
@@ -142,6 +144,8 @@ Suggested launch copy and positioning notes are in:
 - roadmap: [ROADMAP.md](ROADMAP.md)
 - changelog: [CHANGELOG.md](CHANGELOG.md)
 - contributions: [CONTRIBUTING.md](CONTRIBUTING.md)
+- release process: [docs/release-process.md](docs/release-process.md)
+- partner guide: [docs/partner-integration-guide.md](docs/partner-integration-guide.md)
 
 ## Production Relationship
 

--- a/docs/partner-integration-guide.md
+++ b/docs/partner-integration-guide.md
@@ -1,0 +1,63 @@
+# Partner Integration Guide
+
+This guide explains how partners should approach MapleBridge Open without relying on MapleBridge production systems.
+
+## What partners can build against
+
+Partners should treat MapleBridge Open as a public contract layer for:
+
+- buyer intent normalization
+- seller capability normalization
+- bilateral matching explanations
+- connector abstraction boundaries
+- notification triggers
+
+## Recommended integration path
+
+1. Start with `schemas/intent.schema.json`.
+2. Read `protocols/agent-protocol.md`.
+3. Read `frameworks/match-engine.md`.
+4. Use `connectors/crawler-connectors.md` only as an abstraction reference.
+5. Keep your own credentials, data sources, prompts, and thresholds private.
+
+## Suggested partner architecture
+
+- one buyer-side adapter
+- one seller-side adapter
+- one normalization layer
+- one local matching layer
+- one notification layer
+
+MapleBridge Open is designed to describe boundaries, not to replace a partner's production controls.
+
+## Boundary rules
+
+Partners should not expect:
+
+- MapleBridge production data access
+- MapleBridge production matching scores
+- MapleBridge production email systems
+- MapleBridge private enrichment pipelines
+- MapleBridge internal sourcing heuristics
+
+## Good first integration targets
+
+- intake form normalization
+- supplier profile normalization
+- explainable match summaries
+- partner-side notification triggers
+
+## When to use Discussions
+
+Use GitHub Discussions for:
+
+- contract interpretation questions
+- partner integration questions
+- schema extension ideas
+- example payload requests
+
+Do not use Discussions for:
+
+- production support for `maplebridge.io/app`
+- private data requests
+- private threshold questions

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,54 @@
+# Release Process
+
+MapleBridge Open uses lightweight semantic versioning for the public contract layer.
+
+## Scope of a release
+
+A public release can include:
+
+- schema updates
+- protocol documentation changes
+- match framework clarifications
+- connector interface changes
+- notification interface changes
+- open docs and demo-boundary docs
+
+A public release must not expose:
+
+- `maplebridge.io/app`
+- production APIs
+- private prompts
+- live production data
+- private thresholds or internal trust heuristics
+
+## Versioning guidance
+
+- `v0.x.y`: early public contract layer
+- minor bump: new docs, new fields, new non-breaking interfaces
+- patch bump: clarifications, typo fixes, examples, small corrections
+
+## Release checklist
+
+1. Update `CHANGELOG.md`.
+2. Confirm `README.md` links are still correct.
+3. Confirm new docs stay inside the public boundary.
+4. Create or update a roadmap item if the release changes project direction.
+5. Publish the GitHub release with clear release notes.
+6. If useful, open or link a Discussions thread for follow-up questions.
+
+## Release note pattern
+
+Keep each release note short and operational:
+
+- what changed
+- what was added
+- what stays out of scope
+- where builders should start reading
+
+## Post-release
+
+After each release:
+
+- update the pinned meta issue if it changes operating priorities
+- route ecosystem questions into Discussions
+- link the release from external channels only when the release adds meaningful public value


### PR DESCRIPTION
## Summary
Add two public operating docs to support the first release cadence:
- release process
- partner integration guide

## Why
The repository now has a pinned issue, Discussions, a first roadmap, and a first tagged release. These docs make the public operating layer easier to follow for maintainers and partners.

## Production impact
None. This change stays inside the public `maplebridge-open` repository and does not touch `maplebridge.io/app`.