### PR TITLE
Sync crawler connector public boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,9 @@ This changelog covers the open contract layer only. It does not describe changes
 - A2A positioning note
 - Apache-2.0 license
 - roadmap and contribution guidance
+
+### Changed
+
+- clarified that crawler ingestion can run as multiple specialized workers instead of a single crawler path
+- clarified the public search-connector model as primary search plus optional fallback search
+- clarified that filtering and normalization boundaries are public, while concrete query strategies and provider tuning remain private

--- a/connectors/crawler-connectors.md
+++ b/connectors/crawler-connectors.md
@@ -2,21 +2,66 @@
 
 The public connector layer explains how ingestion sources should normalize into the matching workflow.
 
+## Connector Topology
+
+MapleBridge Open treats crawler ingestion as a layered system, not a single crawler process.
+
+At the public boundary, that means:
+
+- one or more source-facing crawler workers can run independently
+- crawler workers can specialize by market or role
+- a demand-oriented workflow can stay separate from a broader SME discovery workflow
+- all crawler outputs still normalize into the same matching layer
+
+This keeps the public contract stable even when production crawler topology changes.
+
 ## Connector Contract
 
 Input:
 
 - source
+- connector kind
 - fetch context
 - raw payload
 
 Output:
 
 - normalized company record
+- normalized role hint
 - contact hints
 - provenance
 - freshness
 - extraction confidence
+
+## Search Connector Model
+
+The public connector model assumes:
+
+- a primary search connector
+- an optional fallback search connector
+- filtering before normalization
+- normalization before match scoring
+
+In other words, the public boundary supports a pattern like:
+
+1. query a preferred search source
+2. fall back to a secondary source if coverage is weak
+3. filter out low-value or non-commercial domains
+4. normalize surviving records into the shared matching workflow
+
+The exact providers, query templates, rate limits, and block-handling rules remain private.
+
+## Normalization Expectations
+
+A crawler connector should be able to emit enough structured hints for downstream review:
+
+- probable role: buyer or supplier
+- probable company identity
+- probable contact surface
+- product or category hints
+- provenance and extraction confidence
+
+The public layer documents these expectations, not the production heuristics used to derive them.
 
 ## Why This Stays Abstract
 
@@ -24,8 +69,11 @@ The abstraction can be public.
 
 The following stay private:
 
+- production crawler topology details
 - production source lists
 - seed queries
 - crawl cadence
+- fallback-provider tuning
+- domain allow/block rules
 - anti-blocking strategies
 - spam filtering logic


### PR DESCRIPTION
## Summary
Sync the public crawler connector docs with today's production-side crawler restructuring.

## What changed
- document crawler ingestion as a layered topology
- document primary search plus optional fallback search at the public boundary
- clarify normalized role-hint expectations
- record the change in `CHANGELOG.md`

## What stays private
Real source lists, query templates, allow/block rules, cadence, anti-blocking logic, and provider tuning remain private.

## Production impact
None. This PR only updates the public `maplebridge-open` repository and does not touch `maplebridge.io/app`.