### PR TITLE
docs: add packaging buyer intent example

### DIFF
--- a/examples/sample-payloads.json
+++ b/examples/sample-payloads.json
@@ -45,6 +45,29 @@
       ],
       "confidence": 0.82,
       "review_state": "needs_review"
+    },
+    {
+      "intent_id": "buyer-recycled-mailer-boxes-us",
+      "role": "buyer",
+      "language": "en",
+      "product_category": "packaging",
+      "summary": "Recycled mailer box order for US skincare brand launch",
+      "country": "United States",
+      "moq": {
+        "value": 2000,
+        "unit": "units"
+      },
+      "compliance": [
+        "FSC-certified paper",
+        "soy-based ink"
+      ],
+      "fit_constraints": [
+        "custom printed mailer boxes",
+        "ISTA-style drop resistance",
+        "delivery to Los Angeles before September launch"
+      ],
+      "confidence": 0.88,
+      "review_state": "needs_review"
     }
   ],
   "supplier_intents": [


### PR DESCRIPTION
## Summary

Add a concrete buyer intent example for a real packaging sourcing scenario to the public sample payloads.

## Type

- [x] Buyer intent example
- [ ] Supplier capability example
- [ ] Match explanation
- [ ] Connector boundary
- [ ] Documentation wording
- [ ] Schema compatibility note
- [ ] Other

## Public Boundary Check

- [x] This does not require MapleBridge production code.
- [x] This does not include customer, buyer, or supplier private data.
- [x] This does not expose crawler sources, ranking thresholds, credentials, or private operational details.

## Validation

- [x] `npm run demo`
- [x] `npm run check:json`
- [x] Documentation links checked

Fixes #11
