### PR TITLE
docs: add supplier capability examples for OEM and low-MOQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,41 @@ Supplier capability:
 }
 ```
 
+Additional supplier capability examples:
+
+```json
+[
+  {
+    "intent_id": "supplier-dongguan-beauty-private-label",
+    "role": "supplier",
+    "language": "en",
+    "product_category": "beauty & personal care",
+    "summary": "Dongguan private-label skincare factory for trial launches",
+    "country": "China",
+    "moq": { "value": 500, "unit": "units per SKU" },
+    "compliance": ["GMP workshop", "MSDS support", "EU cosmetic filing docs"],
+    "channels": ["OEM", "ODM", "private label", "EU export"],
+    "fit_constraints": ["silkscreen logo", "small-batch carton design", "sample approval before mass production"],
+    "confidence": 0.88,
+    "review_state": "machine_ready"
+  },
+  {
+    "intent_id": "supplier-ningbo-kitchenware-low-moq",
+    "role": "supplier",
+    "language": "en",
+    "product_category": "kitchenware",
+    "summary": "Ningbo kitchenware maker with low-MOQ OEM support",
+    "country": "China",
+    "moq": { "value": 150, "unit": "units per design" },
+    "compliance": ["LFGB", "FDA food contact", "drop-test packaging support"],
+    "channels": ["OEM", "North America export", "EU export"],
+    "fit_constraints": ["starter order for 2-3 SKUs", "barcode labeling", "gift-box packaging"],
+    "confidence": 0.85,
+    "review_state": "needs_review"
+  }
+]
+```
+
 ## Public Boundary
 
 Open in this repository:


### PR DESCRIPTION
## Summary

Add two realistic supplier capability examples in the README to show OEM/private-label and low-MOQ manufacturer profiles.

## Type

- [ ] Buyer intent example
- [x] Supplier capability example
- [ ] Match explanation
- [ ] Connector boundary
- [ ] Documentation wording
- [ ] Schema compatibility note
- [ ] Other

## Public Boundary Check

- [x] This does not require MapleBridge production code.
- [x] This does not include customer, buyer, or supplier private data.
- [x] This does not expose crawler sources, ranking thresholds, credentials, or private operational details.

## Validation

- [x] `npm run demo`
- [x] `npm run check:json`
- [x] Documentation links checked

Fixes #12
